### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,27 @@
 setting.py
+# Created by https://www.gitignore.io/api/laravel
+
+### Laravel ###
+/vendor
+node_modules/
+npm-debug.log
+
+# Laravel 4 specific
+bootstrap/compiled.php
+app/storage/
+
+# Laravel 5 & Lumen specific
+public/storage
+public/hot
+storage/*.key
+.env.*.php
+.env.php
+.env
+Homestead.yaml
+Homestead.json
+
+# Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
+.rocketeer/
+
+
+# End of https://www.gitignore.io/api/laravel


### PR DESCRIPTION
<!-- Please fill out the title field according to our pull-requests conventions -->

### Description

Agregamos al gitinore soporte para laravel
por ejemplo la carpeta node_modules/ y el archivo npm-debug.log ya no se suben aproyecto
ver el .gitignore

resolves #XXXXX
review @alguien

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] Easy to rollback to the previous state
- [ ] Works fine with the old state in parallel (backward compatible)
- [ ] It doesn't depend on other branches/PR
- [x] Has tests.
